### PR TITLE
Gradle 8 support

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ plugins {
 }
 
 group = "com.stepango.aar2jar"
-version = "0.6"
+version = "0.7"
 
 gradlePlugin {
     plugins {

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 plugins {
     id "org.jetbrains.kotlin.jvm" version "1.3.41"
     id "java-gradle-plugin"
-    id "org.gradle.kotlin.kotlin-dsl" version "1.2.8"
+    id "org.gradle.kotlin.kotlin-dsl" version "2.1.6"
     id "com.gradle.plugin-publish" version "0.10.1"
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.4.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-all.zip

--- a/src/main/java/com/stepango/aar2jar/Aar2Jar.kt
+++ b/src/main/java/com/stepango/aar2jar/Aar2Jar.kt
@@ -3,22 +3,23 @@ package com.stepango.aar2jar
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.artifacts.Configuration
-import org.gradle.api.artifacts.transform.ArtifactTransform
+import org.gradle.api.artifacts.transform.InputArtifact
+import org.gradle.api.artifacts.transform.TransformAction
+import org.gradle.api.artifacts.transform.TransformOutputs
+import org.gradle.api.artifacts.transform.TransformParameters
 import org.gradle.api.artifacts.type.ArtifactTypeDefinition
+import org.gradle.api.file.FileSystemLocation
 import org.gradle.api.internal.artifacts.ArtifactAttributes.ARTIFACT_FORMAT
-import org.gradle.api.plugins.JavaBasePlugin
-import org.gradle.api.plugins.JavaPluginConvention
+import org.gradle.api.plugins.JavaPluginExtension
+import org.gradle.api.provider.Provider
 import org.gradle.api.tasks.SourceSet
 import org.gradle.api.tasks.SourceSetContainer
 import org.gradle.kotlin.dsl.dependencies
 import org.gradle.kotlin.dsl.get
 import org.gradle.kotlin.dsl.getByType
 import org.gradle.kotlin.dsl.the
-import org.gradle.plugins.ide.idea.IdeaPlugin
 import org.gradle.plugins.ide.idea.model.IdeaModel
-import java.io.File
 import java.io.FileOutputStream
-import java.lang.IllegalArgumentException
 import java.util.zip.ZipFile
 
 class Aar2Jar : Plugin<Project> {
@@ -55,10 +56,9 @@ class Aar2Jar : Plugin<Project> {
         }
 
         project.dependencies {
-            registerTransform {
+            registerTransform(AarToJarTransform::class.java) {
                 from.attribute(ARTIFACT_FORMAT, "aar")
                 to.attribute(ARTIFACT_FORMAT, ArtifactTypeDefinition.JAR_TYPE)
-                artifactTransform(AarToJarTransform::class.java)
             }
         }
 
@@ -97,7 +97,7 @@ fun Configuration.baseConfiguration(project: Project, name: String, f: SourceSet
         attribute(ARTIFACT_FORMAT, ArtifactTypeDefinition.JAR_TYPE)
     }
     project.pluginManager.withPlugin("java") {
-        val sourceSets = project.the<JavaPluginConvention>().sourceSets
+        val sourceSets = project.the<JavaPluginExtension>().sourceSets
         sourceSets.withName(name, f)
     }
 }
@@ -106,23 +106,25 @@ fun SourceSetContainer.withName(name: String, f: SourceSet.() -> Unit) {
     this[name]?.apply { f(this) } ?: whenObjectAdded { if (this.name == name) f(this) }
 }
 
-class AarToJarTransform : ArtifactTransform() {
+abstract class AarToJarTransform : TransformAction<TransformParameters.None> {
 
-    override fun transform(input: File): List<File> {
-        val file = File(outputDirectory, input.name.replace(".aar", ".jar"))
+    @InputArtifact
+    abstract fun getInputArtifact(): Provider<FileSystemLocation?>?
+
+    override fun transform(outputs: TransformOutputs) {
+        val input = getInputArtifact()!!.get().asFile
+        val output = outputs.file(input.name.replace(".aar", ".jar"))
+
         ZipFile(input).use { zipFile ->
             zipFile.entries()
-                    .toList()
-                    .first { it.name == "classes.jar" }
-                    .let(zipFile::getInputStream)
-                    .use { input ->
-                        FileOutputStream(file).use { output ->
-                            input.copyTo(output)
-                        }
+                .toList()
+                .first { it.name == "classes.jar" }
+                .let(zipFile::getInputStream)
+                .use { input ->
+                    FileOutputStream(output).use { output ->
+                        input.copyTo(output)
                     }
+                }
         }
-
-        return listOf(file)
     }
-
 }


### PR DESCRIPTION
Migrate project to Gradle 7.2 and new Transform API and `JavaPluginExtension`.
`ArtifactTransform` and `JavaPluginConvention` was removed in Gradle 8